### PR TITLE
 Add deposit to fund for UI testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:loan:withdraw": "mocha test/loan/lender/withdraw $npm_package_options_mocha",
     "test:loan:funds": "mocha test/loan/lender/funds $npm_package_options_mocha",
     "test:loan:e2e": "mocha test/loan/lender/e2e $npm_package_options_mocha",
-    "deploy:fund": "mocha test/loan/lender/deploy/fund $npm_package_options_mocha"
+    "deploy:fund": "mocha test/loan/lender/deploy/fund $npm_package_options_mocha",
+    "deploy:deposit": "mocha test/loan/lender/deploy/deposit $npm_package_options_mocha"
   },
   "options": {
     "mocha": "--timeout 200000 --recursive --exit"

--- a/src/api/routes/loan.js
+++ b/src/api/routes/loan.js
@@ -65,6 +65,17 @@ router.get('/funds/:fundId', asyncHandler(async (req, res, next) => {
   res.json(fund.json())
 }))
 
+router.get('/funds/ticker/:principal', asyncHandler(async (req, res, next) => {
+  const { params } = req
+
+  console.log('params', params)
+
+  const fund = await Fund.findOne({ principal: params.principal }).exec()
+  if (!fund) return next(res.createError(401, 'Fund not found'))
+
+  res.json(fund.json())
+}))
+
 router.post('/funds/new', asyncHandler(async (req, res, next) => {
   console.log('start /funds/new')
   let fund

--- a/test/loan/lender/deploy/deposit.js
+++ b/test/loan/lender/deploy/deposit.js
@@ -6,7 +6,7 @@ const BN = require('bignumber.js')
 
 const { chains, connectMetaMask } = require('../../../common')
 const { fundArbiter, fundAgent, generateSecretHashesArbiter, fundWeb3Address, getAgentAddress, getTestObjects } = require('../../loanCommon')
-const { createCustomFund } = require('../setup/fundSetup')
+const { depositToFund } = require('../setup/fundSetup')
 const { currencies } = require('../../../../src/utils/fx')
 const { numToBytes32 } = require('../../../../src/utils/finance')
 const web3 = require('../../../../src/utils/web3')
@@ -26,14 +26,14 @@ const arbiterChain = chains.web3WithArbiter
 const principal = process.env.PRINCIPAL
 const amount = process.env.AMOUNT
 
-function deployFund (web3Chain) {
-  describe(`Create Custom ${principal} Loan Fund`, () => {
-    it(`should create a new ${amount} loan fund and deposit funds into it`, async () => {
+function depositForFund (web3Chain) {
+  describe(`Deposit ${principal} to Loan Fund`, () => {
+    it(`should deposit ${amount} ${principal} to loan fund`, async () => {
       const [token, funds] = await getTestObjects(web3Chain, principal, ['erc20', 'funds'])
       const agentAddress = await getAgentAddress(server)
       const balanceBefore = await token.methods.balanceOf(process.env[`${principal}_LOAN_FUNDS_ADDRESS`]).call()
 
-      const fundId = await createCustomFund(web3Chain, arbiterChain, amount, principal) // Create Custom Loan Fund with 200 DAI
+      const fundId = await depositToFund(web3Chain, amount, principal) // Create Custom Loan Fund with 200 DAI
 
       const balanceAfter = await token.methods.balanceOf(process.env[`${principal}_LOAN_FUNDS_ADDRESS`]).call()
       const { lender } = await funds.methods.funds(numToBytes32(fundId)).call()
@@ -51,10 +51,10 @@ async function testSetup (web3Chain) {
   await fundWeb3Address(web3Chain)
 }
 
-describe('Lender Agent - Deploy - Fund', () => {
+describe('Lender Agent - Deploy - Deposit', () => {
   describe('MetaMask', () => {
     connectMetaMask()
     before(async function () { await testSetup(chains.web3WithMetaMask) })
-    deployFund(chains.web3WithMetaMask)
+    depositForFund(chains.web3WithMetaMask)
   })
 })


### PR DESCRIPTION
This PR enables anyone testing the agent to easily deposit additional funds by simply running

`PRINCIPAL=USDC AMOUNT=300 npm run deploy:deposit`