### PR TITLE
Improve fund tx create process for checking receipt

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "commander": "^2.20.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
+    "date.js": "^0.3.3",
     "decimal.js": "^10.2.0",
     "dotenv": "^8.0.0",
     "ethereumjs-util": "^6.1.0",

--- a/src/models/EthTx.js
+++ b/src/models/EthTx.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose')
 const timestamps = require('mongoose-timestamp')
 
-const EthTransactionSchema = new mongoose.Schema({
+const EthTxSchema = new mongoose.Schema({
   from: {
     type: String,
     index: true
@@ -32,7 +32,7 @@ const EthTransactionSchema = new mongoose.Schema({
   }
 })
 
-EthTransactionSchema.methods.json = function () {
+EthTxSchema.methods.json = function () {
   const json = this.toJSON()
   json.id = json._id
 
@@ -42,10 +42,10 @@ EthTransactionSchema.methods.json = function () {
   return json
 }
 
-EthTransactionSchema.static('fromTxParams', function (params) {
-  return new EthTransaction(params)
+EthTxSchema.static('fromTxParams', function (params) {
+  return new EthTx(params)
 })
 
-EthTransactionSchema.plugin(timestamps)
-const EthTransaction = mongoose.model('EthTransaction', EthTransactionSchema)
-module.exports = EthTransaction
+EthTxSchema.plugin(timestamps)
+const EthTx = mongoose.model('EthTx', EthTxSchema)
+module.exports = EthTx

--- a/src/models/Fund.js
+++ b/src/models/Fund.js
@@ -68,7 +68,7 @@ const FundSchema = new mongoose.Schema({
     type: Boolean,
     index: true
   },
-  initiationHash: {
+  createTxHash: {
     type: String,
     index: true
   },
@@ -80,7 +80,7 @@ const FundSchema = new mongoose.Schema({
     type: Number,
     index: true
   },
-  ethTransactionId: {
+  ethTxId: {
     type: String,
     index: true
   },

--- a/src/worker/loan/funds.js
+++ b/src/worker/loan/funds.js
@@ -3,7 +3,7 @@ const keccak256 = require('keccak256')
 const { ensure0x } = require('@liquality/ethereum-utils')
 
 const Fund = require('../../models/Fund')
-const EthTransaction = require('../../models/EthTransaction')
+const EthTx = require('../../models/EthTx')
 const { rateToSec } = require('../../utils/finance')
 const { loadObject } = require('../../utils/contracts')
 const { currencies } = require('../../utils/fx')
@@ -12,6 +12,8 @@ const { setTxParams } = require('./utils/web3Transaction')
 const { getFundParams } = require('./utils/fundParams')
 const web3 = require('../../utils/web3')
 const { toWei, hexToNumber } = web3().utils
+
+const date = require('date.js')
 
 function defineFundsJobs (agenda) {
   agenda.define('create-fund', async (job, done) => {
@@ -33,91 +35,58 @@ function defineFundsJobs (agenda) {
       txData = funds.methods.create(...fundParams).encodeABI()
     }
 
-    const ethTransaction = await setTxParams(txData, lenderAddress, fundContractAddress, fund)
+    const ethTx = await setTxParams(txData, lenderAddress, fundContractAddress, fund)
 
-    fund.ethTransactionId = ethTransaction.id
+    fund.ethTxId = ethTx.id
     await fund.save()
 
-    await agenda.schedule(process.env.CHECK_TX_INTERVAL, 'verify-create-fund', { fundModelId: fund.id })
-
-    const testing = process.env.NODE_ENV === 'test' && process.env.TEST_TX_OVERWRITE
-    if (testing === true) { return } // Don't create fund if testing tx overwrite flow
-
-    await createFund(ethTransaction.json(), fund, agenda, done)
+    await createFund(ethTx, fund, agenda, done)
   })
 
   agenda.define('verify-create-fund', async (job, done) => {
     const { data } = job.attrs
-    const { ethTransactionId, fundModelId } = data
-
-    console.log('VERIFY CREATE FUND')
+    const { fundModelId } = data
 
     const fund = await Fund.findOne({ _id: fundModelId }).exec()
     if (!fund) return console.log('Error: Fund not found')
-
-    if (fund.status === 'CREATING' || fund.status === 'INITIATED') {
-      const ethTransaction = await EthTransaction.findOne({ _id: fund.ethTransactionId })
-      if (!ethTransaction) return console.log('Error: EthTransaction not found')
-
-      const { gasPrice: currentGasPrice } = ethTransaction
-
-      let fastPriceInWei
-      try {
-        const { data: gasPricesFromOracle } = await axios(`https://www.etherchain.org/api/gasPriceOracle`)
-        const { fast } = gasPricesFromOracle
-        fastPriceInWei = parseInt(toWei(fast, 'gwei'))
-      } catch(e) {
-        fastPriceInWei = currentGasPrice
-      }
-      
-      if (fastPriceInWei > (currentGasPrice * 1.1)) {
-        ethTransaction.gasPrice = Math.ceil(fastPriceInWei)
-      } else {
-        ethTransaction.gasPrice = Math.ceil(currentGasPrice * 1.15)
-      }
-
-      await ethTransaction.save()
-
-      await agenda.schedule(process.env.CHECK_TX_INTERVAL, 'verify-create-fund', { fundModelId: fund.id })
-
-      console.log('BUMPING TX FEE')
-
-      await createFund(ethTransaction.json(), fund, agenda, done)
-    }
-  })
-
-  agenda.define('check-tx', async (job, done) => {
-    const { data } = job.attrs
-    const { transactionHash } = data
+    const { createTxHash } = fund
 
     console.log('CHECKING RECEIPT')
 
-    const receipt = await web3().eth.getTransactionReceipt(transactionHash)
-    console.log('receipt', receipt)
+    const receipt = await web3().eth.getTransactionReceipt(createTxHash)
 
     if (receipt === null) {
-      await agenda.schedule(process.env.CHECK_TX_INTERVAL, 'check-tx', { transactionHash })
-    }
-    
-    done()
-  })
-}
+      console.log('RECEIPT IS NULL')
 
-async function createFund (txParams, fund, agenda, done) {
-  web3().eth.sendTransaction(txParams)
-  .on('transactionHash', async (transactionHash) => {
-    fund.fundCreateTxHash = transactionHash
-    fund.status = 'CREATING'
-    fund.save()
-    console.log('FUND CREATING')
-    await agenda.now('check-tx', { transactionHash })
-  })
-  .on('confirmation', async (confirmationNumber, receipt) => {
-    const { principal, collateral } = fund
-    const { loanMarket } = await getMarketModels(principal, collateral)
-    const { minConf } = loanMarket
+      const ethTx = await EthTx.findOne({ _id: fund.ethTxId }).exec()
+      if (!ethTx) return console.log('Error: EthTx not found')
 
-    if (confirmationNumber === minConf) {
+      if (date(process.env.BUMP_TX_INTERVAL) > ethTx.updatedAt && fund.status !== 'FAILED') {
+        const { gasPrice: currentGasPrice } = ethTx
+        let fastPriceInWei
+        try {
+          const { data: gasPricesFromOracle } = await axios(`https://www.etherchain.org/api/gasPriceOracle`)
+          const { fast } = gasPricesFromOracle
+          fastPriceInWei = parseInt(toWei(fast, 'gwei'))
+        } catch(e) {
+          fastPriceInWei = currentGasPrice
+        }
+
+        if (fastPriceInWei > (currentGasPrice * 1.1)) {
+          ethTx.gasPrice = Math.ceil(fastPriceInWei)
+        } else {
+          ethTx.gasPrice = Math.ceil(currentGasPrice * 1.15)
+        }
+
+        await ethTx.save()
+        console.log('BUMPING TX FEE')
+
+        await createFund(ethTx, fund, agenda, done)
+      } else {
+        await agenda.schedule(process.env.CHECK_TX_INTERVAL, 'verify-create-fund', { fundModelId })
+      }
+    } else {
+      console.log('RECEIPT IS NOT NULL')
       const fundCreateLog = receipt.logs.filter(log => log.topics[0] === ensure0x(keccak256('Create(bytes32)').toString('hex')))
 
       if (fundCreateLog.length > 0) {
@@ -126,15 +95,29 @@ async function createFund (txParams, fund, agenda, done) {
         fund.fundId = hexToNumber(fundId)
         fund.status = 'CREATED'
         fund.save()
-        console.log('FUND CREATED')
+        console.log(`${fund.principal} FUND #${fund.fundId} CREATED`)
         done()
       } else {
         console.error('Error: Fund Id could not be found in transaction logs')
       }
     }
+
+    done()
+  })
+}
+
+async function createFund (ethTx, fund, agenda, done) {
+  web3().eth.sendTransaction(ethTx.json())
+  .on('transactionHash', async (transactionHash) => {
+    fund.ethTxId = ethTx.id
+    fund.createTxHash = transactionHash
+    fund.status = 'CREATING'
+    fund.save()
+    console.log(`${fund.principal} FUND CREATING`)
+    await agenda.now('verify-create-fund', { fundModelId: fund.id })
   })
   .on('error', (error) => {
-    console.log('FUND CREATION FAILED')
+    console.log(`${fund.principal} FUND CREATION FAILED`)
     console.log(error)
     fund.status = 'FAILED'
     fund.save()

--- a/src/worker/loan/loans.js
+++ b/src/worker/loan/loans.js
@@ -1,5 +1,5 @@
 const Loan = require('../../models/Loan')
-const EthTransaction = require('../../models/EthTransaction')
+const EthTx = require('../../models/EthTx')
 const { numToBytes32 } = require('../../utils/finance')
 const { loadObject } = require('../../utils/contracts')
 const { ensure0x, remove0x } = require('@liquality/ethereum-utils')
@@ -42,24 +42,24 @@ function defineLoansJobs (agenda) {
 
     const txData = funds.methods.request(...loanParams).encodeABI()
 
-    const ethTransaction = await setTxParams(txData, ensure0x(lenderPrincipalAddress), process.env[`${principal}_LOAN_FUNDS_ADDRESS`], loan)
+    const ethTx = await setTxParams(txData, ensure0x(lenderPrincipalAddress), process.env[`${principal}_LOAN_FUNDS_ADDRESS`], loan)
 
-    await agenda.schedule('in 2 minutes', 'verify-request-loan', { ethTransactionId: ethTransaction.id, loanModelId: loan.id })
+    await agenda.schedule('in 2 minutes', 'verify-request-loan', { ethTxId: ethTx.id, loanModelId: loan.id })
 
-    await requestLoan(ethTransaction.json(), loan, agenda, done)
+    await requestLoan(ethTx.json(), loan, agenda, done)
   })
 
   agenda.define('verify-request-loan', async (job, done) => {
     const { data } = job.attrs
-    const { ethTransactionId, loanModelId } = data
+    const { ethTxId, loanModelId } = data
 
-    const ethTransaction = await EthTransaction.findOne({ _id: ethTransactionId }).exec()
-    if (!ethTransaction) return console.log('Error: EthTransaction not found')
+    const ethTx = await EthTx.findOne({ _id: ethTxId }).exec()
+    if (!ethTx) return console.log('Error: EthTx not found')
 
     const loan = await Loan.findOne({ _id: loanModelId }).exec()
     if (!loan) return console.log('Error: Loan not found')
 
-    // await requestLoan(ethTransaction, loan, agenda, done)
+    // await requestLoan(ethTx, loan, agenda, done)
   })
 
   agenda.define('verify-lock-collateral', async (job, done) => {

--- a/src/worker/loan/utils/web3Transaction.js
+++ b/src/worker/loan/utils/web3Transaction.js
@@ -1,5 +1,5 @@
 const web3 = require('../../../utils/web3')
-const EthTransaction = require('../../../models/EthTransaction')
+const EthTx = require('../../../models/EthTx')
 
 async function setTxParams (data, from, to, instance) {
   const txParams = { data, from, to }
@@ -22,10 +22,10 @@ async function setTxParams (data, from, to, instance) {
   txParams.gasPrice = gasPrice
   txParams.gasLimit = gasLimit + 3000000
 
-  const ethTransaction = EthTransaction.fromTxParams(txParams)
-  await ethTransaction.save()
+  const ethTx = EthTx.fromTxParams(txParams)
+  await ethTx.save()
 
-  return ethTransaction
+  return ethTx
 }
 
 module.exports = {

--- a/test/loan/lender/funds.js
+++ b/test/loan/lender/funds.js
@@ -101,7 +101,7 @@ function testFunds (web3Chain, ethNode) {
       const { body } = await chai.request(server).post('/funds/new').send(fundParams)
       const { id: fundModelId } = body
 
-      await sleep(5000)
+      await sleep(14000)
       await ethNode.client.getMethod('jsonrpc')('miner_start')
 
       const fundId = await checkFundCreated(fundModelId)
@@ -221,7 +221,7 @@ function testFunds (web3Chain, ethNode) {
       const { body: fundNewBodySuccess } = await chai.request(server).post('/funds/new').send(successFundParams)
       const { id: fundModelIdSuccess } = fundNewBodySuccess
 
-      await sleep(5000)
+      await sleep(10000)
 
       const { body: fundsIdBodySuccess } = await chai.request(server).get(`/funds/${fundModelIdSuccess}`)
       const { status: statusSuccess } = fundsIdBodySuccess
@@ -231,17 +231,23 @@ function testFunds (web3Chain, ethNode) {
   })
 
   // Only run this test after commenting out `await createFund(txParams, fund, done)`. Ganache does not currently support a mempool
-  describe('Transaction fee bumping', () => {
-    before(function () { rewriteEnv('.env', 'TEST_TX_OVERWRITE', true) })
-    after(function() { rewriteEnv('.env', 'TEST_TX_OVERWRITE', false) })
+  // describe.only('Transaction fee bumping', () => {
+  //   before(function () { rewriteEnv('.env', 'TEST_TX_OVERWRITE', true) })
+  //   after(function() { rewriteEnv('.env', 'TEST_TX_OVERWRITE', false) })
 
-    it('should bump transaction if current tx stuck in mempool for CHECK_TX_INTERVAL', async () => {
-      const currentTime = Math.floor(new Date().getTime() / 1000)
+  //   it('should bump transaction if current tx stuck in mempool for CHECK_TX_INTERVAL', async () => {
+  //     const currentTime = Math.floor(new Date().getTime() / 1000)
 
-      const fundParams = fundFixtures.customFundWithFundExpiryIn100Days(currentTime, 'USDC')
-      const { status } = await chai.request(server).post('/funds/new').send(fundParams)
-    })
-  })
+  //     await sleep(5000)
+
+  //     const fundParams = fundFixtures.customFundWithFundExpiryIn100Days(currentTime, 'USDC')
+  //     const { status } = await chai.request(server).post('/funds/new').send(fundParams)
+
+  //     await sleep(13000)
+
+  //     rewriteEnv('.env', 'TEST_TX_OVERWRITE', false)
+  //   })
+  // })
 }
 
 async function createFundFromFixture (web3Chain, fixture, principal_, amount) {

--- a/test/loan/lender/setup/fundSetup.js
+++ b/test/loan/lender/setup/fundSetup.js
@@ -62,7 +62,7 @@ async function checkFundCreated (fundModelId) {
     await sleep(1000)
     const { body } = await chai.request(server).get(`/funds/${fundModelId}`)
     const { status } = body
-    console.log('status', status)
+    console.log(status)
     if (status === 'CREATED') {
       created = true
       fundId = body.fundId


### PR DESCRIPTION
This PR improves the fund tx create process, by checking receipt rather than waiting for confirmations. 

Essentially, `verify-create-fund` checks whether the `receipt` for a tx exists, and if so, marks the transaction as created. Otherwise, it keeps checking, until the `BUMP_TX_INTERVAL` where it overwrites the pending transaction. 