### PR TITLE
Add reset calls for UI testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:loan:funds": "mocha test/loan/lender/funds $npm_package_options_mocha",
     "test:loan:e2e": "mocha test/loan/lender/e2e $npm_package_options_mocha",
     "deploy:fund": "mocha test/loan/lender/deploy/fund $npm_package_options_mocha",
-    "deploy:deposit": "mocha test/loan/lender/deploy/deposit $npm_package_options_mocha"
+    "deploy:deposit": "mocha test/loan/lender/deploy/deposit $npm_package_options_mocha",
+    "reset:jobs": "mocha test/loan/lender/reset/jobs $npm_package_options_mocha",
+    "reset:mnemonic": "mocha test/loan/lender/reset/mnemonic $npm_package_options_mocha"
   },
   "options": {
     "mocha": "--timeout 200000 --recursive --exit"

--- a/test/loan/lender/reset/jobs.js
+++ b/test/loan/lender/reset/jobs.js
@@ -1,0 +1,9 @@
+const { sleep } = require('@liquality/utils')
+const { cancelJobs } = require('../../loanCommon')
+
+describe('Cancel all jobs', () => {
+  it('should cancel all jobs', async () => {
+    await cancelJobs()
+    await sleep(2000)
+  })
+})

--- a/test/loan/lender/reset/mnemonic.js
+++ b/test/loan/lender/reset/mnemonic.js
@@ -1,0 +1,8 @@
+const { generateMnemonic } = require('bip39')
+const { rewriteEnv } = require('../../../common')
+
+describe('Reset Mnemonic', () => {
+  it('should generate Mnemonic and insert into .env', async () => {
+    rewriteEnv('.env', 'MNEMONIC', `"${generateMnemonic(128)}"`)
+  })
+})


### PR DESCRIPTION
This PR adds reset calls for UI testing. 

For example `npm run reset:mnemonic` which generates a mnemonic and inserts it into the `env` and `npm run reset:jobs` which kills all current jobs