### PR TITLE
Implement arbiter agents routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5658,6 +5658,11 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7810,6 +7815,14 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
+      }
+    },
+    "request-ip": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.1.3.tgz",
+      "integrity": "sha512-J3qdE/IhVM3BXkwMIVO4yFrvhJlU3H7JH16+6yHucadT4fePnR8dyh+vEs6FIx0S2x5TCt2ptiPfHcn0sqhbYQ==",
+      "requires": {
+        "is_js": "^0.9.0"
       }
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:lender:loans": "mocha test/loan/lender/loans $npm_package_options_mocha",
     "test:lender:e2e": "mocha test/loan/lender/e2e $npm_package_options_mocha",
     "test:arbiter:funds": "mocha test/loan/arbiter/funds $npm_package_options_mocha",
+    "test:arbiter:agents": "mocha test/loan/arbiter/agents $npm_package_options_mocha",
     "deploy:fund": "mocha test/loan/lender/deploy/fund $npm_package_options_mocha",
     "deploy:deposit": "mocha test/loan/lender/deploy/deposit $npm_package_options_mocha",
     "reset:jobs": "mocha test/loan/lender/reset/jobs $npm_package_options_mocha",
@@ -90,6 +91,7 @@
     "mongoose-timestamp": "^0.6.0",
     "node-metamask": "^1.1.2",
     "path": "^0.12.7",
+    "request-ip": "^2.1.3",
     "truffle-hdwallet-provider": "^1.0.17",
     "web3": "^1.2.1"
   },

--- a/src/api/routes/loan/arbiter/agents.js
+++ b/src/api/routes/loan/arbiter/agents.js
@@ -1,0 +1,38 @@
+const asyncHandler = require('express-async-handler')
+const requestIp = require('request-ip')
+
+const { verifySignature } = require('../../../../utils/signatures')
+
+const Agent = require('../../../../models/Agent')
+
+function defineAgentsRouter (router) {
+  router.post('/agents/new', asyncHandler(async (req, res, next) => {
+    console.log('start /agents/new')
+    const { body } = req
+    const { ethSigner, principalAddress, collateralPublicKey } = body
+    const endpoint = requestIp.getClientIp(req)
+
+    // TODO: implement verify signature
+
+    const params = { ethSigner, principalAddress, collateralPublicKey, endpoint }
+
+    const agent = Agent.fromAgentParams(params)
+
+    await agent.save()
+
+    console.log('end /agents/new')
+
+    res.json(agent.json())
+  }))
+
+  router.get('/agents/:agentModelId', asyncHandler(async (req, res, next) => {
+    const { params } = req
+
+    const agent = await Agent.findOne({ _id: params.agentModelId }).exec()
+    if (!agent) return next(res.createError(401, 'Agent not found'))
+
+    res.json(agent.json())
+  }))
+}
+
+module.exports = defineAgentsRouter

--- a/src/api/routes/loan/arbiter/index.js
+++ b/src/api/routes/loan/arbiter/index.js
@@ -1,0 +1,9 @@
+const defineAgentsRouter = require('./agents')
+
+// TODO: fix http error response codes in all routes
+
+function defineArbiterRoutes (router) {
+  defineAgentsRouter(router)
+}
+
+module.exports = defineArbiterRoutes

--- a/src/api/routes/loan/index.js
+++ b/src/api/routes/loan/index.js
@@ -1,10 +1,16 @@
 const router = require('express').Router()
+const { isArbiter } = require('../../../utils/env')
 const defineAgentRoutes = require('./agent')
 const defineJobsRoutes = require('./jobs')
 const defineLenderRoutes = require('./lender/index')
+const defineArbiterRoutes = require('./arbiter/index')
 
 defineAgentRoutes(router)
 defineJobsRoutes(router)
-defineLenderRoutes(router)
+if (isArbiter()) {
+  defineArbiterRoutes(router)
+} else {
+  defineLenderRoutes(router)
+}
 
 module.exports = router

--- a/src/api/routes/loan/lender/funds.js
+++ b/src/api/routes/loan/lender/funds.js
@@ -27,10 +27,13 @@ function defineFundsRouter (router) {
 
   router.post('/funds/new', asyncHandler(async (req, res, next) => {
     console.log('start /funds/new')
+
     let fund
     const agenda = req.app.get('agenda')
     const { body } = req
     const { principal, collateral, custom } = body
+
+    // TODO: implement verify signature
 
     fund = await Fund.findOne({ principal, collateral, status: { $ne: 'FAILED' } }).exec()
     if (fund && fund.status === 'CREATED') return next(res.createError(401, 'Fund was already created. Agent can only have one Loan Fund'))

--- a/src/models/Agent.js
+++ b/src/models/Agent.js
@@ -1,0 +1,42 @@
+const mongoose = require('mongoose')
+
+const AgentSchema = new mongoose.Schema({
+  ethSigner: {
+    type: String,
+    index: true
+  },
+  endpoint: {
+    type: String,
+    index: true
+  },
+  principalAddress: {
+    type: String,
+    index: true
+  },
+  collateralPublicKey: {
+    type: String,
+    index: true
+  }
+})
+
+AgentSchema.methods.json = function () {
+  const json = this.toJSON()
+  json.id = json._id
+
+  delete json._id
+  delete json.__v
+
+  return json
+}
+
+AgentSchema.static('fromAgentParams', function (params) {
+  return new Agent({
+    ethSigner: params.ethSigner,
+    endpoint: params.endpoint,
+    principalAddress: params.principalAddress,
+    collateralPublicKey: params.collateralPublicKey
+  })
+})
+
+const Agent = mongoose.model('Agent', AgentSchema)
+module.exports = Agent

--- a/src/models/LoanMarket.js
+++ b/src/models/LoanMarket.js
@@ -79,7 +79,7 @@ LoanMarketSchema.methods.getAgentAddresses = async function () {
   return {
     principalAddress: principalAddresses[0],
     collateralAddress: collateralAddresses[0].address,
-    collateralPublicKey: collateralAddresses[0].publicKey
+    collateralPublicKey: collateralAddresses[0].publicKey.toString('hex')
   }
 }
 

--- a/test/loan/arbiter/agents.js
+++ b/test/loan/arbiter/agents.js
@@ -1,0 +1,39 @@
+/* eslint-env mocha */
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.should()
+const expect = chai.expect
+
+chai.use(chaiHttp)
+chai.use(chaiAsPromised)
+
+const { chains } = require('../../common')
+const { getWeb3Address } = require('../util/web3Helpers')
+const { getAgentAddresses, fundAgent } = require('../loanCommon')
+
+const server = 'http://localhost:3032/api/loan'
+
+function testArbiterAgents () {
+  describe('/POST agents/new', () => {
+    it('should POST agent data and return agent object', async () => {
+      const ethSigner = await getWeb3Address(chains.web3WithHDWallet)
+      const { principalAddress, collateralPublicKey } = await getAgentAddresses(server)
+
+      const { status, body } = await chai.request(server).post('/agents/new').send({ ethSigner, principalAddress, collateralPublicKey })
+
+      expect(status).to.equal(200)
+      console.log('body', body)
+    })
+  })
+}
+
+async function testSetup () {
+  await fundAgent(server)
+}
+
+describe('Arbiter Agent - Agents', () => {
+  beforeEach(async function () { await testSetup() })
+  testArbiterAgents()
+})

--- a/test/loan/arbiter/funds.js
+++ b/test/loan/arbiter/funds.js
@@ -2,15 +2,12 @@
 const chai = require('chai')
 const chaiHttp = require('chai-http')
 const chaiAsPromised = require('chai-as-promised')
-const BN = require('bignumber.js')
 const { generateMnemonic } = require('bip39')
 
 const { createFundAndRequestMultipleTimes } = require('./common')
 const { fundAgent, fundLender, getTestObjects, cancelJobs, fundWeb3Address } = require('../loanCommon')
 const { chains, connectMetaMask, rewriteEnv } = require('../../common')
 const { getWeb3Address } = require('../util/web3Helpers')
-
-const web3 = require('web3')
 
 chai.should()
 const expect = chai.expect
@@ -19,8 +16,6 @@ chai.use(chaiHttp)
 chai.use(chaiAsPromised)
 
 const server = 'http://localhost:3032/api/loan'
-
-const lenderChain =  chains.web3WithLender
 
 function testFunds (web3Chain, ethNode) {
   describe('Create Custom Loan Fund', () => {

--- a/test/loan/lender/withdraw.js
+++ b/test/loan/lender/withdraw.js
@@ -4,7 +4,6 @@ const chaiHttp = require('chai-http')
 const chaiAsPromised = require('chai-as-promised')
 const BN = require('bignumber.js')
 const { generateMnemonic } = require('bip39')
-const { sleep } = require('@liquality/utils')
 
 const { chains, connectMetaMask, rewriteEnv } = require('../../common')
 const { fundWeb3Address } = require('../loanCommon')

--- a/test/loan/loanCommon.js
+++ b/test/loan/loanCommon.js
@@ -155,6 +155,7 @@ module.exports = {
   fundAgent,
   fundTokens,
   getAgentAddress,
+  getAgentAddresses,
   generateSecretHashesArbiter,
   getLockParams,
   getTestObject,


### PR DESCRIPTION
This PR implements arbiter agents routes. 

This includes 

`/agents/new`

example request

{
  ethSigner: '0xd2587bF14d305Dfb56CA17712C3f1540a0e87873',
  principalAddress: '0xa42c043c85B56CC5fE628BAAA855516f9d886B5c',
  collateralPublicKey:
   '02f9149d01005d090948cdcc1a92537cd3cb6e3fb650111f3b8a2e3342d48ea687'
}

example response

{
  ethSigner: '0xd2587bF14d305Dfb56CA17712C3f1540a0e87873',
  endpoint: '::ffff:127.0.0.1',
  principalAddress: '0xa42c043c85B56CC5fE628BAAA855516f9d886B5c',
  collateralPublicKey:
   '02f9149d01005d090948cdcc1a92537cd3cb6e3fb650111f3b8a2e3342d48ea687',
  id: '5d8915fa29c7101d1bc0041c'
}

and `/agents/:agentId`