### PR TITLE
Add ability to do second and third liquidations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ jobs:
         - CI=false npm run test:lender:tx
         - CI=false npm run test:modules
         - CI=false npm run coverage
+    - stage: Test Multiple Sales
+      script:
+        - CI=false npm run test:lender:second_sales
     - stage: Test Sales
       script:
         - CI=false npm run test:lender:sales

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:lender:funds": "mocha test/loan/lender/funds $npm_package_options_mocha",
     "test:lender:loans": "mocha test/loan/lender/loans $npm_package_options_mocha",
     "test:lender:sales": "mocha test/loan/lender/sales $npm_package_options_mocha",
+    "test:lender:second_sales": "mocha test/loan/lender/secondSales $npm_package_options_mocha",
     "test:lender:collateral": "mocha test/loan/lender/collateral $npm_package_options_mocha",
     "test:lender:e2e": "mocha test/loan/lender/e2e $npm_package_options_mocha",
     "test:lender:tx": "mocha test/loan/lender/tx $npm_package_options_mocha",

--- a/src/api/routes/loan/lender/index.js
+++ b/src/api/routes/loan/lender/index.js
@@ -1,5 +1,6 @@
 const defineFundsRouter = require('./funds')
 const defineLoansRouter = require('./loans')
+const defineSalesRouter = require('./sales')
 const defineWithdrawRoutes = require('./withdraw')
 
 // TODO: fix http error response codes in all routes
@@ -7,6 +8,7 @@ const defineWithdrawRoutes = require('./withdraw')
 function defineLenderRoutes (router) {
   defineFundsRouter(router)
   defineLoansRouter(router)
+  defineSalesRouter(router)
   defineWithdrawRoutes(router)
 }
 

--- a/src/api/routes/loan/lender/sales.js
+++ b/src/api/routes/loan/lender/sales.js
@@ -11,7 +11,7 @@ function defineSalesRouter (router) {
 
     const { params, body } = req
     const { principal, saleId } = params
-    const { arbiterSigs, refundableAmount, seizableAmount } = body
+    const { arbiterSigs } = body
 
     const sale = await Sale.findOne({ principal, saleId }).exec()
     if (!sale) return next(res.createError(401, 'Sale not found'))
@@ -44,28 +44,28 @@ function defineSalesRouter (router) {
           refundable: [Buffer.from(arbiterSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
           seizable: [Buffer.from(arbiterSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
         }
-  
+
         console.log('lockTxHash, sigs, ...swapParams, outputs', lockTxHash, sigs, ...swapParams, outputs)
         const multisigSendTxRaw = await loan.collateralClient().loan.collateralSwap.multisigMake(lockTxHash, sigs, ...swapParams, outputs)
         console.log('multisigSendTxRaw', multisigSendTxRaw)
-  
+
         const txHash = await loan.collateralClient().chain.sendRawTransaction(multisigSendTxRaw)
         console.log('txHash', txHash)
-  
+
         res.json({ txHash })
-      } catch(e) {
+      } catch (e) {
         const sigs = {
           refundable: [Buffer.from(lenderSigs.refundableSig, 'hex'), Buffer.from(arbiterSigs.refundableSig, 'hex')],
           seizable: [Buffer.from(lenderSigs.seizableSig, 'hex'), Buffer.from(arbiterSigs.seizableSig, 'hex')]
         }
-  
+
         console.log('lockTxHash, sigs, ...swapParams, outputs', lockTxHash, sigs, ...swapParams, outputs)
         const multisigSendTxRaw = await loan.collateralClient().loan.collateralSwap.multisigMake(lockTxHash, sigs, ...swapParams, outputs)
         console.log('multisigSendTxRaw', multisigSendTxRaw)
-  
+
         const txHash = await loan.collateralClient().chain.sendRawTransaction(multisigSendTxRaw)
         console.log('txHash', txHash)
-  
+
         res.json({ txHash })
       }
     } else {

--- a/src/api/routes/loan/lender/sales.js
+++ b/src/api/routes/loan/lender/sales.js
@@ -1,0 +1,77 @@
+const asyncHandler = require('express-async-handler')
+
+const Loan = require('../../../../models/Loan')
+const Sale = require('../../../../models/Sale')
+const { getInitArgs } = require('../../../../worker/loan/utils/collateralSwap')
+const { numToBytes32 } = require('../../../../utils/finance')
+
+function defineSalesRouter (router) {
+  router.post('/sales/contract/:principal/:saleId/revert', asyncHandler(async (req, res, next) => {
+    console.log('/sales/contract/:principal/:saleId/revert')
+
+    const { params, body } = req
+    const { principal, saleId } = params
+    const { arbiterSigs, refundableAmount, seizableAmount } = body
+
+    const sale = await Sale.findOne({ principal, saleId }).exec()
+    if (!sale) return next(res.createError(401, 'Sale not found'))
+
+    const { loanModelId, collateral, collateralSwapRefundableP2SHAddress } = sale
+
+    const loan = await Loan.findOne({ _id: loanModelId }).exec()
+    if (!loan) return next(res.createError(401, 'Loan not found'))
+
+    const { loanId, collateralRefundableP2SHAddress, collateralSeizableP2SHAddress } = loan
+
+    const swapParams = await getInitArgs(numToBytes32(loanId), numToBytes32(saleId), principal, collateral)
+
+    const refundableUnspent = await loan.collateralClient().getMethod('getUnspentTransactions')([collateralSwapRefundableP2SHAddress])
+
+    if (refundableUnspent.length > 0) {
+      const lockTxHash = refundableUnspent[0].txid
+      const party = 'lender'
+
+      const outputs = [{ address: collateralRefundableP2SHAddress }, { address: collateralSeizableP2SHAddress }]
+
+      const multisigParams = [lockTxHash, ...swapParams, party, outputs]
+      console.log('multisigParams', multisigParams)
+      console.log('about to multisigWrite')
+      const lenderSigs = await loan.collateralClient().loan.collateralSwap.multisigWrite(...multisigParams)
+      console.log('finished multisigWrite')
+
+      try {
+        const sigs = {
+          refundable: [Buffer.from(arbiterSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+          seizable: [Buffer.from(arbiterSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+        }
+  
+        console.log('lockTxHash, sigs, ...swapParams, outputs', lockTxHash, sigs, ...swapParams, outputs)
+        const multisigSendTxRaw = await loan.collateralClient().loan.collateralSwap.multisigMake(lockTxHash, sigs, ...swapParams, outputs)
+        console.log('multisigSendTxRaw', multisigSendTxRaw)
+  
+        const txHash = await loan.collateralClient().chain.sendRawTransaction(multisigSendTxRaw)
+        console.log('txHash', txHash)
+  
+        res.json({ txHash })
+      } catch(e) {
+        const sigs = {
+          refundable: [Buffer.from(lenderSigs.refundableSig, 'hex'), Buffer.from(arbiterSigs.refundableSig, 'hex')],
+          seizable: [Buffer.from(lenderSigs.seizableSig, 'hex'), Buffer.from(arbiterSigs.seizableSig, 'hex')]
+        }
+  
+        console.log('lockTxHash, sigs, ...swapParams, outputs', lockTxHash, sigs, ...swapParams, outputs)
+        const multisigSendTxRaw = await loan.collateralClient().loan.collateralSwap.multisigMake(lockTxHash, sigs, ...swapParams, outputs)
+        console.log('multisigSendTxRaw', multisigSendTxRaw)
+  
+        const txHash = await loan.collateralClient().chain.sendRawTransaction(multisigSendTxRaw)
+        console.log('txHash', txHash)
+  
+        res.json({ txHash })
+      }
+    } else {
+      return next(res.createError(401, 'No funds to revert'))
+    }
+  }))
+}
+
+module.exports = defineSalesRouter

--- a/src/models/Sale.js
+++ b/src/models/Sale.js
@@ -68,17 +68,23 @@ const SaleSchema = new mongoose.Schema({
     type: String,
     index: true
   },
+  revertTxhash: {
+    type: String,
+    index: true
+  },
   latestCollateralBlock: {
     type: Number,
     index: true
   },
   status: {
     type: String,
-    enum: ['INITIATED', 'COLLATERAL_SENDING', 'COLLATERAL_SENT', 'SECRETS_PROVIDED', 'COLLATERAL_CLAIMED', 'ACCEPTING', 'ACCEPTED', 'CANCELLING', 'CANCELLED', 'FAILED'],
+    enum: ['INITIATED', 'COLLATERAL_SENDING', 'COLLATERAL_SENT', 'SECRETS_PROVIDED', 'COLLATERAL_CLAIMED', 'COLLATERAL_REVERTING', 'COLLATERAL_REVERTED', 'ACCEPTING', 'ACCEPTED', 'CANCELLING', 'CANCELLED', 'FAILED'],
     index: true,
     default: 'INITIATED'
   }
 })
+
+SaleSchema.index({ principal: 1, saleId: 1 }, { unique: true, partialFilterExpression: { principal: { $type: 'string' }, saleId: { $type: 'int' } } })
 
 SaleSchema.methods.principalClient = function () {
   return clients[currencies[this.principal].chain]

--- a/src/worker/loan/loans/status.js
+++ b/src/worker/loan/loans/status.js
@@ -189,48 +189,50 @@ function defineLoanStatusJobs (agenda) {
 
               const saleModel = saleModels[0]
 
-              // const saleModel = await Sale.findOne({ loanModelId: loan.id }).exec()
-
               if (isArbiter() && saleModel && saleModel.status !== 'FAILED') {
                 const collateralBlockHeight = await saleModel.collateralClient().getMethod('getBlockHeight')()
-                const { latestCollateralBlock, claimTxHash, status } = saleModel
+                const { latestCollateralBlock, claimTxHash, revertTxHash, status } = saleModel
 
-                if (saleModel && collateralBlockHeight > latestCollateralBlock && !claimTxHash) {
+                if (saleModel && collateralBlockHeight > latestCollateralBlock && !claimTxHash && !revertTxHash) {
                   agenda.now('verify-collateral-claim', { saleModelId: saleModel.id })
                 } else if (saleModel && status === 'COLLATERAL_CLAIMED' && claimTxHash) {
                   console.log('COLLATERAL WAS CLAIMED, SPIN UP JOB TO ACCEPT')
                   agenda.now('accept-sale', { saleModelId: saleModel.id })
-                } else if (saleModel && status === 'COLLATERAL_REVERTING' && (collateralBlockHeight - latestCollateralBlock) >= 3 && claimTxHash) {
-                  // Send bitcoin back to original address
-                  // Spin up job
-                  // Then verify that liquidate occurs and create new sale record
                 }
               } else if (!isArbiter() && !saleModel) {
                 await agenda.now('init-liquidation', { loanModelId: loan.id })
               } else if (!isArbiter() && saleModel && saleModel.status !== 'FAILED') {
                 const sales = getObject('sales', principal)
                 const token = getObject('erc20', principal)
-                const { accepted } = await sales.methods.sales(numToBytes32(saleModel.saleId)).call()
-                if (accepted) {
-                  saleModel.status = 'ACCEPTED'
-                  await saleModel.save()
 
-                  const fundModel = await Fund.findOne({ principal }).exec()
-                  const deposit = await Deposit.findOne({ fundModelId: fundModel.id, saleId: saleModel.saleId }).exec()
+                const next = await sales.methods.next(numToBytes32(loanId)).call()
+                console.log('next', next)
+                console.log('saleModels.length', saleModels.length)
+                if (parseInt(next) !== saleModels.length) {
+                  await agenda.now('init-liquidation', { loanModelId: loan.id })
+                } else {
+                  const { accepted } = await sales.methods.sales(numToBytes32(saleModel.saleId)).call()
+                  if (accepted) {
+                    saleModel.status = 'ACCEPTED'
+                    await saleModel.save()
 
-                  if (!deposit) {
-                    const owedToLender = await loans.methods.owedToLender(numToBytes32(loanId)).call()
-                    const tokenBalance = await token.methods.balanceOf(principalAddress).call()
+                    const fundModel = await Fund.findOne({ principal }).exec()
+                    const deposit = await Deposit.findOne({ fundModelId: fundModel.id, saleId: saleModel.saleId }).exec()
 
-                    if (tokenBalance >= owedToLender) {
-                      const unit = currencies[principal].unit
+                    if (!deposit) {
+                      const owedToLender = await loans.methods.owedToLender(numToBytes32(loanId)).call()
+                      const tokenBalance = await token.methods.balanceOf(principalAddress).call()
 
-                      const amountToDeposit = fromWei(owedToLender.toString(), unit)
-                      await agenda.now('fund-deposit', { fundModelId: fundModel.id, amountToDeposit, saleId: saleModel.saleId })
+                      if (tokenBalance >= owedToLender) {
+                        const unit = currencies[principal].unit
+
+                        const amountToDeposit = fromWei(owedToLender.toString(), unit)
+                        await agenda.now('fund-deposit', { fundModelId: fundModel.id, amountToDeposit, saleId: saleModel.saleId })
+                      }
+                    } else {
+                      loan.status = 'LIQUIDATED'
+                      await loan.save()
                     }
-                  } else {
-                    loan.status = 'LIQUIDATED'
-                    await loan.save()
                   }
                 }
               }

--- a/src/worker/loan/sales/claim.js
+++ b/src/worker/loan/sales/claim.js
@@ -14,61 +14,90 @@ function defineSalesClaimJobs (agenda) {
 
     const sale = await Sale.findOne({ _id: saleModelId }).exec()
     if (!sale) return console.log('Error: Sale not found')
-    const { initTxHash } = sale
+    const { initTxHash, latestCollateralBlock, collateralSwapRefundableP2SHAddress } = sale
 
-    console.log('initTxHash', initTxHash)
+    const collateralBlockHeight = await sale.collateralClient().getMethod('getBlockHeight')()
 
-    if (NETWORK === 'mainnet' || NETWORK === 'kovan') {
-      let baseUrl
-      if (NETWORK === 'mainnet') {
-        baseUrl = 'https://blockstream.info'
-      } else {
-        baseUrl = 'https://blockstream.info/testnet'
-      }
-      try {
-        console.log(`${baseUrl}/api/tx/${initTxHash}/outspend/0`)
-        const { status, data: spendInfo } = await axios.get(`${baseUrl}/api/tx/${initTxHash}/outspend/0`)
+    console.log('collateralBlockHeight', collateralBlockHeight)
+    console.log('latestCollateralBlock', latestCollateralBlock)
 
-        if (status === 200) {
-          if (spendInfo.spent === true) {
-            console.log('COLLATERAL_CLAIMED FOUND')
-            sale.claimTxHash = spendInfo.txid
-            sale.status = 'COLLATERAL_CLAIMED'
-          }
-        }
-      } catch (e) {
-        handleError(e)
-      }
+    const { timestamp: collateralBlockHeightTimestamp } = await sale.collateralClient().getMethod('getBlockByNumber')(parseInt(collateralBlockHeight))
+    const { timestamp: latestCollateralBlockTimestamp } = await sale.collateralClient().getMethod('getBlockByNumber')(parseInt(latestCollateralBlock))
+
+    const minTimePassed = 60 * 15 // 2 hours
+    const minTimeHasPassed = (collateralBlockHeightTimestamp - latestCollateralBlockTimestamp) >= minTimePassed
+    console.log('collateralBlockHeightTimestamp', collateralBlockHeightTimestamp)
+    console.log('latestCollateralBlockTimestamp', latestCollateralBlockTimestamp)
+
+    const minBlocksPassed = 3 // at least 2 block confirmations on the collateral before reverting
+    const minBlocksHavePassed = (collateralBlockHeight - latestCollateralBlock) >= minBlocksPassed
+
+    const refundableUnspent = await sale.collateralClient().getMethod('getUnspentTransactions')([collateralSwapRefundableP2SHAddress])
+
+    console.log('minTimeHasPassed', minTimeHasPassed)
+    console.log('minBlocksHavePassed', minBlocksHavePassed)
+
+    if (minTimeHasPassed && minBlocksHavePassed && refundableUnspent.length > 0) {
+      // revert collateral
+      agenda.now('revert-init-liquidation', { saleModelId: sale.id })
+
+      done()
     } else {
-      const collateralBlockHeight = await sale.collateralClient().chain.getBlockHeight()
-      const { latestCollateralBlock } = sale
-      let curBlock = latestCollateralBlock + 1
+      console.log('initTxHash', initTxHash)
 
-      while (curBlock <= collateralBlockHeight) {
-        const block = await sale.collateralClient().chain.getBlockByNumber(curBlock)
-        const txs = await Promise.all(block.transactions.map((txid) => {
-          return sale.collateralClient().getMethod('getTransactionByHash')(txid)
-        }))
+      if (NETWORK === 'mainnet' || NETWORK === 'kovan') {
+        let baseUrl
+        if (NETWORK === 'mainnet') {
+          baseUrl = 'https://blockstream.info'
+        } else {
+          baseUrl = 'https://blockstream.info/testnet'
+        }
+        try {
+          console.log(`${baseUrl}/api/tx/${initTxHash}/outspend/0`)
+          const { status, data: spendInfo } = await axios.get(`${baseUrl}/api/tx/${initTxHash}/outspend/0`)
 
-        for (let i = 0; i < txs.length; i++) {
-          const tx = txs[i]
-          const vins = tx._raw.vin
-          for (let j = 0; j < vins.length; j++) {
-            const vin = vins[j]
-            if (vin.txid === initTxHash) {
+          if (status === 200) {
+            // add more logic to tell if it's been claimed or if it's been reverted
+            if (spendInfo.spent === true) {
               console.log('COLLATERAL_CLAIMED FOUND')
-              sale.claimTxHash = tx.hash
+              sale.claimTxHash = spendInfo.txid
               sale.status = 'COLLATERAL_CLAIMED'
-              curBlock = collateralBlockHeight + 1
-              break
             }
           }
+        } catch (e) {
+          handleError(e)
+        }
+      } else {
+        const collateralBlockHeight = await sale.collateralClient().chain.getBlockHeight()
+        const { latestCollateralBlock } = sale
+        let curBlock = latestCollateralBlock + 1
+
+        while (curBlock <= collateralBlockHeight) {
+          const block = await sale.collateralClient().chain.getBlockByNumber(curBlock)
+          const txs = await Promise.all(block.transactions.map((txid) => {
+            return sale.collateralClient().getMethod('getTransactionByHash')(txid)
+          }))
+
+          for (let i = 0; i < txs.length; i++) {
+            const tx = txs[i]
+            const vins = tx._raw.vin
+            for (let j = 0; j < vins.length; j++) {
+              const vin = vins[j]
+              if (vin.txid === initTxHash) {
+                console.log('COLLATERAL_CLAIMED FOUND')
+                sale.claimTxHash = tx.hash
+                sale.status = 'COLLATERAL_CLAIMED'
+                curBlock = collateralBlockHeight + 1
+                break
+              }
+            }
+          }
+
+          curBlock++
         }
 
-        curBlock++
+        sale.latestCollateralBlock = collateralBlockHeight
       }
-
-      sale.latestCollateralBlock = collateralBlockHeight
     }
 
     await sale.save()

--- a/src/worker/loan/sales/claim.js
+++ b/src/worker/loan/sales/claim.js
@@ -24,7 +24,7 @@ function defineSalesClaimJobs (agenda) {
     const { timestamp: collateralBlockHeightTimestamp } = await sale.collateralClient().getMethod('getBlockByNumber')(parseInt(collateralBlockHeight))
     const { timestamp: latestCollateralBlockTimestamp } = await sale.collateralClient().getMethod('getBlockByNumber')(parseInt(latestCollateralBlock))
 
-    const minTimePassed = 60 * 15 // 2 hours
+    const minTimePassed = 60 * 105 // 1 hour 45 minutes
     const minTimeHasPassed = (collateralBlockHeightTimestamp - latestCollateralBlockTimestamp) >= minTimePassed
     console.log('collateralBlockHeightTimestamp', collateralBlockHeightTimestamp)
     console.log('latestCollateralBlockTimestamp', latestCollateralBlockTimestamp)
@@ -32,12 +32,12 @@ function defineSalesClaimJobs (agenda) {
     const minBlocksPassed = 3 // at least 2 block confirmations on the collateral before reverting
     const minBlocksHavePassed = (collateralBlockHeight - latestCollateralBlock) >= minBlocksPassed
 
-    const refundableUnspent = await sale.collateralClient().getMethod('getUnspentTransactions')([collateralSwapRefundableP2SHAddress])
+    const refundableSwapUnspent = await sale.collateralClient().getMethod('getUnspentTransactions')([collateralSwapRefundableP2SHAddress])
 
     console.log('minTimeHasPassed', minTimeHasPassed)
     console.log('minBlocksHavePassed', minBlocksHavePassed)
 
-    if (minTimeHasPassed && minBlocksHavePassed && refundableUnspent.length > 0) {
+    if (minTimeHasPassed && minBlocksHavePassed && refundableSwapUnspent.length > 0) {
       // revert collateral
       agenda.now('revert-init-liquidation', { saleModelId: sale.id })
 

--- a/src/worker/loan/sales/index.js
+++ b/src/worker/loan/sales/index.js
@@ -1,11 +1,13 @@
 const { defineSalesInitJobs } = require('./init')
 const { defineSalesClaimJobs } = require('./claim')
 const { defineSalesAcceptJobs } = require('./accept')
+const { defineSalesRevertJobs } = require('./revert')
 
 function defineSalesJobs (agenda) {
   defineSalesInitJobs(agenda)
   defineSalesClaimJobs(agenda)
   defineSalesAcceptJobs(agenda)
+  defineSalesRevertJobs(agenda)
 }
 
 module.exports = {

--- a/src/worker/loan/sales/init.js
+++ b/src/worker/loan/sales/init.js
@@ -225,7 +225,12 @@ function defineSalesInitJobs (agenda) {
           const { loanModelId } = sale
 
           const loan = await Loan.findOne({ _id: loanModelId }).exec()
-          const secret = loan.lenderSecrets[1]
+          const { loanId } = loan
+
+          const sales = getObject('sales', principal)
+          const next = await sales.methods.next(numToBytes32(loanId)).call()
+
+          const secret = loan.lenderSecrets[parseInt(next)]
 
           if (sha256(secret) === sale.secretHashB) {
             console.log('LENDER SECRET MATCHES')

--- a/src/worker/loan/sales/init.js
+++ b/src/worker/loan/sales/init.js
@@ -141,6 +141,7 @@ function defineSalesInitJobs (agenda) {
         }
 
         const latestCollateralBlock = await loan.collateralClient().getMethod('getBlockHeight')()
+        console.log('init latestCollateralBlock', latestCollateralBlock)
         sale.latestCollateralBlock = latestCollateralBlock
         await sale.save()
 

--- a/src/worker/loan/sales/revert.js
+++ b/src/worker/loan/sales/revert.js
@@ -1,0 +1,154 @@
+const axios = require('axios')
+const { sha256 } = require('@liquality/crypto')
+const Sale = require('../../../models/Sale')
+const Loan = require('../../../models/Loan')
+const Secret = require('../../../models/Secret')
+const Agent = require('../../../models/Agent')
+const AgendaJob = require('../../../models/AgendaJob')
+const { numToBytes32 } = require('../../../utils/finance')
+const { getObject } = require('../../../utils/contracts')
+const { getInterval } = require('../../../utils/intervals')
+const { getLockArgs } = require('../utils/collateral')
+const { getInitArgs } = require('../utils/collateralSwap')
+const { isArbiter } = require('../../../utils/env')
+const { getEndpoint } = require('../../../utils/endpoints')
+const handleError = require('../../../utils/handleError')
+
+const web3 = require('web3')
+const { hexToNumber } = web3.utils
+
+function defineSalesRevertJobs (agenda) {
+  agenda.define('revert-init-liquidation', async (job, done) => {
+    console.log('revert-init-liquidation')
+
+    try {
+      const { data } = job.attrs
+      const { saleModelId } = data
+
+      const sale = await Sale.findOne({ _id: saleModelId }).exec()
+      const { loanModelId, collateralSwapRefundableP2SHAddress, collateralSwapSeizableP2SHAddress, saleId } = sale
+
+      const loan = await Loan.findOne({ _id: loanModelId }).exec()
+      const { collateralRefundableP2SHAddress, collateralSeizableP2SHAddress, loanId, principal, collateral } = loan
+
+      const swapParams = await getInitArgs(numToBytes32(loanId), numToBytes32(saleId), principal, collateral)
+
+      const refundableUnspent = await loan.collateralClient().getMethod('getUnspentTransactions')([collateralSwapRefundableP2SHAddress])
+
+      if (refundableUnspent.length > 0) {
+        const lockTxHash = refundableUnspent[0].txid
+        const party = 'arbiter'
+
+        const outputs = [{ address: collateralRefundableP2SHAddress }, { address: collateralSeizableP2SHAddress }]
+
+        const multisigParams = [lockTxHash, ...swapParams, party, outputs]
+        console.log('multisigParams', multisigParams)
+        const agentSigs = await loan.collateralClient().loan.collateralSwap.multisigWrite(...multisigParams)
+
+        const exampleRSSigValue = '0000000000000000000000000000000000000000000000000000000000000000'
+        const exampleSig = `30440220${exampleRSSigValue}0220${exampleRSSigValue}01`
+
+        const sigs = {
+          refundable: [Buffer.from(agentSigs.refundableSig, 'hex'), Buffer.from(exampleSig, 'hex')],
+          seizable: [Buffer.from(agentSigs.seizableSig, 'hex'), Buffer.from(exampleSig, 'hex')]
+        }
+
+        console.log('lockTxHash, sigs, ...swapParams, outputs', lockTxHash, sigs, ...swapParams, outputs)
+        const multisigSendTxRaw = await loan.collateralClient().loan.collateralSwap.multisigMake(lockTxHash, sigs, ...swapParams, outputs)
+        console.log('multisigSendTxRaw', multisigSendTxRaw)
+
+        const multisigSendTx = await loan.collateralClient().getMethod('decodeRawTransaction')(multisigSendTxRaw)
+        const multisigSendVouts = multisigSendTx._raw.data.vout
+
+        let refundableAmount, seizableAmount
+        if (multisigSendVouts[0].scriptPubKey.addresses[0] === collateralRefundableP2SHAddress) {
+          refundableAmount = multisigSendVouts[0].value
+          seizableAmount = multisigSendVouts[1].value
+        } else {
+          refundableAmount = multisigSendVouts[1].value
+          seizableAmount = multisigSendVouts[0].value
+        }
+
+        const loans = getObject('loans', principal)
+
+        const { lender: lenderPrincipalAddress } = await loans.methods.loans(numToBytes32(loanId)).call()
+
+        console.log('lenderPrincipalAddress', lenderPrincipalAddress)
+
+        loan.lenderPrincipalAddress = lenderPrincipalAddress
+        await loan.save()
+
+        try {
+          const agent = await Agent.findOne({ principalAddress: lenderPrincipalAddress }).exec()
+          const { url } = agent
+
+          console.log(`${url}/sales/contract/${principal}/${saleId}/revert`)
+          console.log({ principal, saleId, arbiterSigs: agentSigs, refundableAmount, seizableAmount })
+          const { data } = await axios.post(`${url}/sales/contract/${principal}/${saleId}/revert`, { arbiterSigs: agentSigs, refundableAmount, seizableAmount })
+          const { txHash } = data
+
+          sale.revertTxHash = txHash
+          sale.status = 'COLLATERAL_REVERTING'
+          await sale.save()
+
+          await agenda.schedule(getInterval('CHECK_BTC_TX_INTERVAL'), 'verify-revert-init-liquidation', { saleModelId })
+        } catch(e) {
+          console.log('AGENT NOT FOUND OR OFFLINE')
+        }
+      }
+    } catch (e) {
+      console.log('e', e)
+    }
+
+    done()
+  })
+
+  agenda.define('verify-revert-init-liquidation', async (job, done) => {
+    console.log('verify-revert-init-liquidation')
+
+    try {
+      const { data } = job.attrs
+      const { saleModelId } = data
+
+      const sale = await Sale.findOne({ _id: saleModelId }).exec()
+      const { loanModelId } = sale
+
+      const loan = await Loan.findOne({ _id: loanModelId }).exec()
+      const { collateralRefundableP2SHAddress, collateralSeizableP2SHAddress } = loan
+
+      const minConfirmations = 1
+
+      const [refundableBalance, seizableBalance, refundableUnspent, seizableUnspent] = await Promise.all([
+        loan.collateralClient().chain.getBalance([collateralRefundableP2SHAddress]),
+        loan.collateralClient().chain.getBalance([collateralSeizableP2SHAddress]),
+        loan.collateralClient().getMethod('getUnspentTransactions')([collateralRefundableP2SHAddress]),
+        loan.collateralClient().getMethod('getUnspentTransactions')([collateralSeizableP2SHAddress])
+      ])
+
+      const collateralRequirementsMet = (refundableBalance.toNumber() >= 0 && seizableBalance.toNumber() >= 0)
+      const refundableConfirmationRequirementsMet = refundableUnspent.length === 0 ? false : refundableUnspent.every(unspent => unspent.confirmations >= minConfirmations)
+      const seizableConfirmationRequirementsMet = seizableUnspent.length === 0 ? false : seizableUnspent.every(unspent => unspent.confirmations >= minConfirmations)
+
+      if (collateralRequirementsMet && refundableConfirmationRequirementsMet && seizableConfirmationRequirementsMet) {
+        sale.status = 'COLLATERAL_REVERTED'
+        await sale.save()
+      } else {
+        // TODO: check if actually claimed instead
+        
+        const alreadyQueuedJobs = await AgendaJob.find({ name: 'verify-revert-init-liquidation', nextRunAt: { $ne: null }, data: { saleModelId } }).exec()
+
+        if (alreadyQueuedJobs.length <= 0) {
+          await agenda.schedule(getInterval('CHECK_BTC_TX_INTERVAL'), 'verify-revert-init-liquidation', { saleModelId })
+        }
+      }
+    } catch (e) {
+      console.log('e', e)
+    }
+    
+    done()
+  })
+}
+
+module.exports = {
+  defineSalesRevertJobs
+}

--- a/src/worker/loan/utils/collateralSwap.js
+++ b/src/worker/loan/utils/collateralSwap.js
@@ -15,7 +15,7 @@ async function getInitArgs (loanId, saleId, principal, collateral) {
 
   const pubKeys = { borrowerPubKey: remove0x(borrowerPubKey), lenderPubKey: remove0x(lenderPubKey), arbiterPubKey: remove0x(arbiterPubKey), liquidatorPubKeyHash: remove0x(pubKeyHash) }
   const secretHashes = { secretHashA1: remove0x(secretHashA), secretHashB1: remove0x(secretHashB), secretHashC1: remove0x(secretHashC), secretHashD1: remove0x(secretHashD) }
-  const expirations = { swapExpiration, liquidationExpiration }
+  const expirations = { swapExpiration: parseInt(swapExpiration), liquidationExpiration: parseInt(liquidationExpiration) }
 
   return [pubKeys, secretHashes, expirations]
 }

--- a/src/worker/loan/utils/web3Transaction.js
+++ b/src/worker/loan/utils/web3Transaction.js
@@ -165,6 +165,8 @@ async function handleWeb3TransactionError (error, ethTx, instance, agenda, done,
   } else if (String(error).indexOf('Transaction has been reverted by the EVM') >= 0) {
     console.log('Transaction has been reverted by the EVM')
     ethTx.failed = false
+    await ethTx.save()
+    await errorCallback(error, instance)
   } else if (String(error).indexOf('Transaction with the same hash was already imported') >= 0) {
     console.log('Transaction with the same hash was already imported')
   } else if (String(error).indexOf('transaction underpriced') >= 0) {

--- a/test/loan/lender/funds.js
+++ b/test/loan/lender/funds.js
@@ -184,7 +184,7 @@ function testFunds (web3Chain, ethNode) {
       const message = 'Create Non-Custom USDC Loan Fund backed by BTC with Compound Disabled and Maximum Loan Duration of 0 seconds which expires at timestamp 0 and deposit 0 USDC'
       const signature = await web3Chain.client.eth.personal.sign(message, address)
 
-      const { fundParams, fundModelId } = await createFundFromFixture(web3Chain, fixture, 'USDC', 200, message, signature)
+      const { fundParams, fundModelId } = await createFundFromFixture(web3Chain, fixture, 'USDC', 200, message, signature, true)
       console.log(fundParams)
 
       await sleep(5000)
@@ -352,7 +352,7 @@ function testFunds (web3Chain, ethNode) {
   // })
 }
 
-async function createFundFromFixture (web3Chain, fixture, principal_, amount, message, signature) {
+async function createFundFromFixture (web3Chain, fixture, principal_, amount, message, signature, canBeFailed) {
   const currentTime = Math.floor(new Date().getTime() / 1000)
   const agentPrincipalAddress = await getAgentAddress(server)
   const address = await getWeb3Address(web3Chain)
@@ -369,7 +369,7 @@ async function createFundFromFixture (web3Chain, fixture, principal_, amount, me
   const { body } = await chai.request(server).post('/funds/new').send(fundParams)
   const { id: fundModelId } = body
 
-  const fundId = await checkFundCreated(fundModelId)
+  const fundId = await checkFundCreated(fundModelId, canBeFailed)
 
   if (!fundId) {
     return { fundParams, agentAddress: agentPrincipalAddress, amountDeposited: amountToDeposit, fundModelId }

--- a/test/loan/setup/fundSetup.js
+++ b/test/loan/setup/fundSetup.js
@@ -66,7 +66,7 @@ async function depositToFund (web3Chain, amount, principal) {
   return fundId
 }
 
-async function checkFundCreated (fundModelId) {
+async function checkFundCreated (fundModelId, canBeFailed = false) {
   let created = false
   let fundId
   while (!created) {
@@ -77,10 +77,9 @@ async function checkFundCreated (fundModelId) {
     if (status === 'CREATED') {
       created = true
       fundId = body.fundId
+    } else if (canBeFailed && status === 'FAILED') {
+      created = true
     }
-    // else if (status === 'FAILED') {
-    //   created = true
-    // }
   }
 
   return fundId

--- a/test/loan/setup/fundSetup.js
+++ b/test/loan/setup/fundSetup.js
@@ -77,9 +77,10 @@ async function checkFundCreated (fundModelId) {
     if (status === 'CREATED') {
       created = true
       fundId = body.fundId
-    } else if (status === 'FAILED') {
-      created = true
     }
+    // else if (status === 'FAILED') {
+    //   created = true
+    // }
   }
 
   return fundId


### PR DESCRIPTION
### Description

This PR enables the agents to handle 2nd and 3rd liquidations, in the case that the liquidator fails to claim the first liquidations. 

### Submission Checklist :pencil:

- [x] Add `revert-init-liquidation` and `verify-revert-init-liquidation` jobs
- [x] Add logic to 'verify-collateral-claim` for spinning up `revert-init-liquidation`
- [x] Add checks in `status.js` for seeing if agent should `init-liquidation` for 2nd/3rd liquidations
- [x] Add tests for second liquidation
